### PR TITLE
fix not no such template  internal/opengraph.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <title>{{ .Page.Title }}</title>
     <!------ ADD COMMON HEADERS -------->
     {{- partial "header.html" . -}}
-    {{ template "_internal/opengraph.html" . }}
+    {{- partial "opengraph.html" . -}}
     {{ template "_internal/twitter_cards.html" . }}
     <!------ ADD PAGE SPECIFIC HEADERS ------->
     {{ block "header" . }} {{ end }}


### PR DESCRIPTION
This pull request includes a small change to the `layouts/_default/baseof.html` file. The change replaces the use of the `_internal/opengraph.html` template with a custom `opengraph.html` partial for better control over Open Graph metadata.